### PR TITLE
Dynamic kopsenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ $ kopsenv list-remote
 ...
 ```
 
+## Configuration directory
+
+If you would like to configure a different directory than the `KOPSENV_ROOT` to install and manager your Kops versions,
+you can specify a `KOPSENV_CONF_DIR` environment variable.
+
+```sh
+export KOPSENV_CONF_DIR="$HOME/.kopsversions/
+```
+
 ## .kops-version
 
 If you put `.kops-version` file on your project root, or in your home directory, kopsenv detects it and use the version written in it. If the version is `latest` or `latest:<regex>`, the latest matching version currently installed will be selected.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kopsenv
 
-**This is currently a modified version of kopsenv to support using the spotinst kops for versions greater than 1.13.0.** (1.13.1, 1.13.2, 1.14.1, ....)  
+**This is currently a modified version of kopsenv to support using either the vanilla or spotinst kops versions
 
 [Kops](https://github.com/kubernetes/kops) version manager inspired by [tfenv](https://github.com/Zordrak/tfenv).
 
@@ -56,6 +56,7 @@ Install a specific version of Kops. Available options for version:
 
 ```sh
 $ kopsenv install 1.10.0
+$ kopsenv install v1.18.2-f37e7a33d0-spotinst
 $ kopsenv install latest
 $ kopsenv install latest:^1.9
 $ kopsenv install
@@ -76,6 +77,7 @@ Switch a version to use
 
 ```sh
 $ kopsenv use 1.10.0
+$ kopsenv use v1.18.2-f37e7a33d0-spotinst
 $ kopsenv use latest
 $ kopsenv use latest:^1.9
 ```
@@ -89,6 +91,7 @@ Uninstall a specific version of Kops
 
 ```sh
 $ kopsenv uninstall 1.10.0
+$ kopsenv uninstall v1.18.2-f37e7a33d0-spotinst
 $ kopsenv uninstall latest
 $ kopsenv uninstall latest:^1.9
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kopsenv
 
+**This is currently a modified version of kopsenv to support using the spotinst kops for versions greater than 1.13.0.** (1.13.1, 1.13.2, 1.14.1, ....)  
+
 [Kops](https://github.com/kubernetes/kops) version manager inspired by [tfenv](https://github.com/Zordrak/tfenv).
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently kopsenv supports the following OSes, on x86-64 bit archtecture only:
 1. Check out kopsenv into any path (here is `${HOME}/.kopsenv`)
 
   ```sh
-  $ git clone https://github.com/kilna/kopsenv.git ~/.kopsenv
+  $ git clone https://github.com/topfreegames/kopsenv.git ~/.kopsenv
   ```
 
 2. Add `~/.kopsenv/bin` to your `$PATH` any way you like

--- a/bin/kopsenv
+++ b/bin/kopsenv
@@ -24,8 +24,19 @@ if [ -z "${KOPSENV_ROOT}" ]; then
 else
   KOPSENV_ROOT="${KOPSENV_ROOT%/}"
 fi
+
 export KOPSENV_ROOT
+
+if [ -z "${KOPSENV_CONF_DIR}" ]; then
+  KOPSENV_CONF_DIR="${KOPSENV_ROOT}"
+else
+  KOPSENV_CONF_DIR="${KOPSENV_CONF_DIR%/}"
+fi
+
+export KOPSENV_CONF_DIR
+
 PATH="${KOPSENV_ROOT}/libexec:${PATH}"
+
 export PATH
 export KOPSENV_DIR="${PWD}"
 

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -22,7 +22,7 @@ function curlw () {
     TLS_OPT=""
   fi
 
-  curl -w "HTTP_RESPONSE_CODE: %{http_code}" ${TLS_OPT} "$@"
+  curl -w "HTTP_RESPONSE_CODE: %{http_code} \n" ${TLS_OPT} "$@"
 }
 
 kops_platform() {

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -22,7 +22,7 @@ function curlw () {
     TLS_OPT=""
   fi
 
-  curl ${TLS_OPT} "$@"
+  curl -w "HTTP_RESPONSE_CODE: %{http_code}" ${TLS_OPT} "$@"
 }
 
 kops_platform() {

--- a/libexec/kopsenv-exec
+++ b/libexec/kopsenv-exec
@@ -11,12 +11,12 @@
 #   kopsenv exec plan
 #
 # is equivalent to:
-#   PATH="$KOPSENV_ROOT/versions/0.7.0/bin:$PATH" kops plan
+#   PATH="$KOPSENV_CONF_DIR/versions/0.7.0/bin:$PATH" kops plan
 
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
 export KOPSENV_VERSION="$(kopsenv-version-name)"
-KOPS_BIN_PATH="${KOPSENV_ROOT}/versions/${KOPSENV_VERSION}/kops"
+KOPS_BIN_PATH="${KOPSENV_CONF_DIR}/versions/${KOPSENV_VERSION}/kops"
 export PATH="${KOPS_BIN_PATH}:${PATH}"
 "${KOPS_BIN_PATH}" "${@}"

--- a/libexec/kopsenv-exec
+++ b/libexec/kopsenv-exec
@@ -16,7 +16,17 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
+source "${KOPSENV_ROOT}/libexec/helpers"
+
 export KOPSENV_VERSION="$(kopsenv-version-name)"
+
+if [ -z "${KOPSENV_VERSION}" ]; then
+  warn_and_continue "Trying to install the version of .kops-version"
+
+  "${KOPSENV_ROOT}/libexec/kopsenv-install"
+  export KOPSENV_VERSION="$(kopsenv-version-name)"
+fi
+
 KOPS_BIN_PATH="${KOPSENV_CONF_DIR}/versions/${KOPSENV_VERSION}/kops"
 export PATH="${KOPS_BIN_PATH}:${PATH}"
 "${KOPS_BIN_PATH}" "${@}"

--- a/libexec/kopsenv-help
+++ b/libexec/kopsenv-help
@@ -2,7 +2,7 @@
 
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-echo "Usage: kopsenv <command> [<options>]
+echo "Usage: kopsenv <command> [<options>] (SPOTINST MODIFIED)
 
 Commands:
    install       Install a specific version of Kops

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -9,7 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(kopsenv-version-file)"
-  if [ "${version_file}" != "${KOPSENV_ROOT}/version" ]; then
+  if [ "${version_file}" != "${KOPSENV_CONF_DIR}/version" ]; then
     version_requested="$(cat ${version_file} || true)"
   fi
 else
@@ -31,7 +31,7 @@ fi
 version="$(kopsenv-list-remote | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
-dst_path="${KOPSENV_ROOT}/versions/${version}"
+dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then
   echo "Kops v${version} is already installed"
   exit 0

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,17 +40,22 @@ fi
 case $version in 
   1.16.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-d0675687a"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-f1c7b0bf2"
     ;;
 
   1.15.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-6880fb33f"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-ed71f1776"
     ;;
 
   1.15.1)
-    error_and_die "Version $version not supported" && \
-    exit 1
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-6693b7b39"
+    ;;
+
+  1.15.0)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-0850929cd"
     ;;
 
   1.14.1)
@@ -59,13 +64,23 @@ case $version in
     ;;
 
   1.14.0)
-    error_and_die "Version $version not supported" && \
-    exit 1
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-7218af5f3"
+    ;;
+
+  1.13.2)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-8d8cd75b2"
+    ;;
+
+  1.13.1)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-bba8ae2b1"
     ;;
 
   1.13.0)
-    warn_and_continue "Will use normal kops version" && \
-    version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.0-f2e8b3179"
     ;;
 
   *)

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -37,11 +37,48 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-version_url="https://github.com/spotinst/kubernetes-kops/releases/download/${version}"
+case $version in 
+  1.16.0)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-d0675687a"
+    ;;
+
+  1.15.2)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-6880fb33f"
+    ;;
+
+  1.15.1)
+    error_and_die "Version $version not supported" && \
+    exit 1
+    ;;
+
+  1.14.1)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-7a204649f"
+    ;;
+
+  1.14.0)
+    error_and_die "Version $version not supported" && \
+    exit 1
+    ;;
+
+  1.13.0)
+    warn_and_continue "Will use normal kops version" && \
+    version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+    ;;
+
+  *)
+    info "Will use the normal kops" && \
+    version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+    ;;
+
+esac
+
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?
 
-info "Installing Kops v${version}"
+info "Installing Kops ${version}"
 
 # Create a local temporary directory for downloads
 download_tmp="$(mktemp -d kopsenv_download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
@@ -55,6 +92,6 @@ mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
 cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
 chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
 
-info "Installation of kops v${version} successful"
+info "Installation of kops ${version} successful"
 kopsenv-use "$version"
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -24,16 +24,18 @@ elif [[ "${version_requested}" =~ ^latest$ ]]; then
   regex=""
 else
   version="${version_requested}"
-  regex="^${version_requested}$"
+  regex="^v?${version_requested}$"
 fi
 
 [ -n "${version}" ] || error_and_die "Version is not specified"
-version="$(kopsenv-list-remote | grep -e "${regex}" | head -n 1)"
+version="$(kopsenv-list-remote | grep -E "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
+
+prefixed="$(echo ${version} | grep -E '^v')"
 
 dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then
-  echo "Kops v${version} is already installed"
+  echo "Kops ${version} is already installed"
   exit 0
 fi
 
@@ -68,7 +70,7 @@ esac
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?
 
-info "Installing Kops ${version}"
+info "Installing Kops ${1}"
 
 # Create a local temporary directory for downloads
 download_tmp="$(mktemp -d kopsenv_download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
@@ -82,6 +84,15 @@ mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
 cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
 chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
 
-info "Installation of kops ${version} successful"
-kopsenv-use "$version"
+# Add prefixed symlinks
+if [[ -n "${prefixed}" ]]; then
+  link_path="${KOPSENV_CONF_DIR}/versions/${version:1}"
+  ln -s ${dst_path} ${link_path}
+else
+  link_path="${KOPSENV_CONF_DIR}/versions/v${version}"
+  ln -s ${dst_path} ${link_path}
+fi
+
+info "Installation of kops ${1} successful"
+kopsenv-use "${1}"
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -78,11 +78,6 @@ case $version in
     version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-bba8ae2b1"
     ;;
 
-  1.13.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.0-f2e8b3179"
-    ;;
-
   *)
     info "Will use the normal kops" && \
     version_url="https://github.com/kubernetes/kops/releases/download/${version}"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,6 +40,10 @@ if [ -f "${dst_path}/kops" ]; then
 fi
 
 case $version_requested in 
+  1.17.1)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-7acee7466"
+    ;;
   1.16.0)
     info "Will use a spotinst kops" && \
     version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-84c9a54b4"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -37,7 +37,7 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+version_url="https://github.com/spotinst/kubernetes-kops/releases/download/${version}"
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -93,6 +93,6 @@ else
   ln -s ${dst_path} ${link_path}
 fi
 
-info "Installation of kops ${1} successful"
-kopsenv-use "${1}"
+info "Installation of kops ${version_requested} successful"
+kopsenv-use "${version_requested}"
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,42 +40,22 @@ fi
 case $version in 
   1.16.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-661dcd555"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-84c9a54b4"
     ;;
 
   1.15.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-7cdea2829"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-519eaa64c"
     ;;
 
   1.15.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-ca011648e"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-6c8e6908c"
     ;;
 
   1.15.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-214b62aec"
-    ;;
-
-  1.14.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-026ce0a5e"
-    ;;
-
-  1.14.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-279f8a3fd"
-    ;;
-
-  1.13.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-48cc563a2"
-    ;;
-
-  1.13.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-8c76b87cc"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-b41e6e0da"
     ;;
 
   *)

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,42 +40,42 @@ fi
 case $version in 
   1.16.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-9688ee528"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-661dcd555"
     ;;
 
   1.15.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-faed31441"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-7cdea2829"
     ;;
 
   1.15.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-c3f01412f"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-ca011648e"
     ;;
 
   1.15.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-9ad20aefb"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-214b62aec"
     ;;
 
   1.14.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-3e87bcb10"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-026ce0a5e"
     ;;
 
   1.14.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-749a996fe"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-279f8a3fd"
     ;;
 
   1.13.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-dd0f33c4d"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-48cc563a2"
     ;;
 
   1.13.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-478e1d644"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-8c76b87cc"
     ;;
 
   *)

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,6 +40,10 @@ if [ -f "${dst_path}/kops" ]; then
 fi
 
 case $version_requested in 
+  1.18.2)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.18.2-6837c742a1"
+    ;;
   1.17.1)
     info "Will use a spotinst kops" && \
     version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-7acee7466"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -39,7 +39,7 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-case $version in 
+case $version_requested in 
   1.16.0)
     info "Will use a spotinst kops" && \
     version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-84c9a54b4"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,42 +40,42 @@ fi
 case $version in 
   1.16.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-f1c7b0bf2"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-9688ee528"
     ;;
 
   1.15.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-ed71f1776"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-faed31441"
     ;;
 
   1.15.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-6693b7b39"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-c3f01412f"
     ;;
 
   1.15.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-0850929cd"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-9ad20aefb"
     ;;
 
   1.14.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-7a204649f"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.1-3e87bcb10"
     ;;
 
   1.14.0)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-7218af5f3"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.14.0-749a996fe"
     ;;
 
   1.13.2)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-8d8cd75b2"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.2-dd0f33c4d"
     ;;
 
   1.13.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-bba8ae2b1"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.13.1-478e1d644"
     ;;
 
   *)

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -39,14 +39,18 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-case $version_requested in 
+case $version_requested in
   1.18.2)
     info "Will use a spotinst kops" && \
     version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.18.2-6837c742a1"
     ;;
+  1.17.2)
+    info "Will use a spotinst kops" && \
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.2-e4f69d94ce"
+    ;;
   1.17.1)
     info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-7acee7466"
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-8996e8f0f7"
     ;;
   1.16.0)
     info "Will use a spotinst kops" && \

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -39,45 +39,13 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-case $version_requested in
-  1.18.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.18.2-6837c742a1"
-    ;;
-  1.17.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.2-e4f69d94ce"
-    ;;
-  1.17.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-8996e8f0f7"
-    ;;
-  1.16.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-84c9a54b4"
-    ;;
 
-  1.15.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-519eaa64c"
-    ;;
-
-  1.15.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-6c8e6908c"
-    ;;
-
-  1.15.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-b41e6e0da"
-    ;;
-
-  *)
-    info "Will use the normal kops" && \
+if [[ $version_requested == *-spotinst ]]
+then
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/"${version%"-spotinst"}
+else
     version_url="https://github.com/kubernetes/kops/releases/download/${version}"
-    ;;
-
-esac
+fi
 
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?

--- a/libexec/kopsenv-list
+++ b/libexec/kopsenv-list
@@ -6,10 +6,10 @@ source ${KOPSENV_ROOT}/libexec/helpers
 [ ${#} -ne 0 ] \
   && error_and_die "usage: kopsenv list"
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions available. Please install one with: kopsenv install"
 
-[[ -x "${KOPSENV_ROOT}/versions" && -r "${KOPSENV_ROOT}/versions" ]] \
+[[ -x "${KOPSENV_CONF_DIR}/versions" && -r "${KOPSENV_CONF_DIR}/versions" ]] \
   || error_and_die "kopsenv versions directory is inaccessible!"
 
 print_version () {
@@ -20,6 +20,6 @@ print_version () {
     fi
 }
 
-for local_version in $(ls -1 "${KOPSENV_ROOT}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
+for local_version in $(ls -1 "${KOPSENV_CONF_DIR}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
     print_version ${local_version}
 done

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,7 +15,7 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
-json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases)
+json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
 
 echo "$json" \

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,12 +15,12 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
-json=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases)
+json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases)
 (( "$?" )) && exit $?
 
 echo "$json" \
-  | grep 'download/[0-9\.]\{1,\}/kops-'$platform'"' \
+  | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \
   | sed 's/^.*download\///; s/\/.*$//' \
-  | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
+  | sed 's/^[v]//' \
+  | sort -t. -r -k1,1 -k2,2 -k3,3 -k4,4 \
   | uniq
-

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -17,9 +17,17 @@ platform="$(kops_platform)"
 # only curl + POSIX tools
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
-
-echo "$json" \
+json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
+(( "$?" )) && exit $?
+output="$(echo "${json}" \
   | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \
-  | sed 's/^.*download\///; s/\/.*$//' \
+  | sed 's/^.*download\///; s/\/.*$//')"
+
+output="${output}
+$(echo "${json2}" \
+  | grep 'download/[v]\?[0-9\.].*/kops-'$platform'"' \
+  | sed 's/^.*download\///; s/\/.*$/-spotinst/')"
+
+echo "$output" \
   | sort -t. -r -k1,1 -k2,2 -k3,3 -k4,4 \
   | uniq

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,7 +15,7 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
-json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases)
+json=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases)
 (( "$?" )) && exit $?
 
 echo "$json" \

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,9 +15,26 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
+
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
+http_status=$(echo "$json" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
+if [[ http_status != 2* ]]
+then
+   echo "Github API response error:
+$json"
+   exit 1
+fi 
+
 json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
+http_status=$(echo "$json2" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
+if [[ http_status != 2* ]] 
+then 
+   echo "Github API response error:
+${json2}"
+   exit 1
+fi 
+
 (( "$?" )) && exit $?
 output="$(echo "${json}" \
   | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -19,7 +19,7 @@ platform="$(kops_platform)"
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
 http_status=$(echo "$json" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
-if [[ http_status != 2* ]]
+if [[ "${http_status}" != 2* ]]
 then
    echo "Github API response error:
 $json"
@@ -28,7 +28,7 @@ fi
 
 json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
 http_status=$(echo "$json2" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
-if [[ http_status != 2* ]] 
+if [[ "${http_status}" != 2* ]] 
 then 
    echo "Github API response error:
 ${json2}"

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -21,6 +21,5 @@ json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases)
 echo "$json" \
   | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \
   | sed 's/^.*download\///; s/\/.*$//' \
-  | sed 's/^[v]//' \
   | sort -t. -r -k1,1 -k2,2 -k3,3 -k4,4 \
   | uniq

--- a/libexec/kopsenv-uninstall
+++ b/libexec/kopsenv-uninstall
@@ -9,7 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(kopsenv-version-file)"
-  if [ "${version_file}" != "${KOPSENV_ROOT}/version" ];then
+  if [ "${version_file}" != "${KOPSENV_CONF_DIR}/version" ];then
     version_requested="$(cat ${version_file} || true)"
   fi
 else
@@ -31,7 +31,7 @@ fi
 version="$(kopsenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in local"
 
-dst_path="${KOPSENV_ROOT}/versions/${version}"
+dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then 
   info "Uninstall Kops v${version}"
   rm -r "${dst_path}"

--- a/libexec/kopsenv-uninstall
+++ b/libexec/kopsenv-uninstall
@@ -33,8 +33,8 @@ version="$(kopsenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e
 
 dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then 
-  info "Uninstall Kops v${version}"
+  info "Uninstall Kops ${version}"
   rm -r "${dst_path}"
-  info "\033[0;32mKops v${version} is successfully uninstalled\033[0;39m"
+  info "\033[0;32mKops ${version} is successfully uninstalled\033[0;39m"
 fi
 

--- a/libexec/kopsenv-uninstall
+++ b/libexec/kopsenv-uninstall
@@ -31,10 +31,18 @@ fi
 version="$(kopsenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in local"
 
+prefixed="$(echo ${version} | grep -E '^v')"
+if [[ -n "$prefixed" ]]; then
+  link_path="${KOPSENV_CONF_DIR}/versions/${version:1}"
+else
+  link_path="${KOPSENV_CONF_DIR}/versions/v${version}"
+fi
+
 dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then 
   info "Uninstall Kops ${version}"
   rm -r "${dst_path}"
+  rm -rf "${link_path}"
   info "\033[0;32mKops ${version} is successfully uninstalled\033[0;39m"
 fi
 

--- a/libexec/kopsenv-use
+++ b/libexec/kopsenv-use
@@ -32,10 +32,10 @@ else
   regex="^${version_requested}$"
 fi
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions of kops installed. Please install one with: kopsenv install"
 
-version="$(\ls "${KOPSENV_ROOT}/versions" \
+version="$(\ls "${KOPSENV_CONF_DIR}/versions" \
   | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
   | grep -e "${regex}" \
   | head -n 1
@@ -43,7 +43,7 @@ version="$(\ls "${KOPSENV_ROOT}/versions" \
 
 [ -n "${version}" ] || error_and_die "No installed versions of kops matched '${1}'"
 
-target_path=${KOPSENV_ROOT}/versions/${version}
+target_path=${KOPSENV_CONF_DIR}/versions/${version}
 [ -f ${target_path}/kops ] \
   || error_and_die "Version directory for ${version} is present, but the kops binary is not! Manual intervention required."
 [ -x ${target_path}/kops ] \

--- a/libexec/kopsenv-use
+++ b/libexec/kopsenv-use
@@ -49,7 +49,7 @@ target_path=${KOPSENV_CONF_DIR}/versions/${version}
 [ -x ${target_path}/kops ] \
   || error_and_die "Version directory for ${version} is present, but the kops binary is not executable! Manual intervention required. "
 
-info "Switching to v${version}"
+info "Switching to ${version}"
 echo "${version}" > "$(kopsenv-version-file)" || error_and_die "'switch to v${version} failed'"
 kops version client 1>/dev/null || error_and_die "'kops version client' failed. Something is seriously wrong"
 info "Switching completed"

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.8.0"
+version="0.9.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.6.0"
+version="0.6.0 (SPOTINST MODIFIED)"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.12.0"
+version="0.13.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.10.0"
+version="0.11.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.7.0 (SPOTINST MODIFIED)"
+version="0.7.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then
@@ -20,4 +20,4 @@ if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kop
   git_revision="${git_revision#v}"
 fi
 
-echo "kopsenv ${git_revision:-$version}"
+echo "kopsenv ${git_revision:-$version} (SPOTINST MODIFIED)"

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.11.0"
+version="0.12.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.7.0"
+version="0.8.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.13.0"
+version="1.0.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.9.0"
+version="0.10.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.6.0 (SPOTINST MODIFIED)"
+version="0.7.0 (SPOTINST MODIFIED)"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then

--- a/libexec/kopsenv-version-file
+++ b/libexec/kopsenv-version-file
@@ -17,4 +17,4 @@ find_local_version_file() {
   return 1
 }
 
-find_local_version_file "${KOPSENV_DIR}" || find_local_version_file "${HOME}" || echo "${KOPSENV_ROOT}/version"
+find_local_version_file "${KOPSENV_DIR}" || find_local_version_file "${HOME}" || echo "${KOPSENV_CONF_DIR}/version"

--- a/libexec/kopsenv-version-name
+++ b/libexec/kopsenv-version-name
@@ -5,7 +5,7 @@ set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 source ${KOPSENV_ROOT}/libexec/helpers
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions of kops installed. Please install one with: kopsenv install"
 
 KOPSENV_VERSION_FILE="$(kopsenv-version-file)"
@@ -13,7 +13,7 @@ KOPSENV_VERSION="$(cat "${KOPSENV_VERSION_FILE}" || true)"
 
 if [[ "${KOPSENV_VERSION}" =~ ^latest.*$ ]]; then
   [[ "${KOPSENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${KOPSENV_VERSION##*\:}"
-  version="$(\ls "${KOPSENV_ROOT}/versions" \
+  version="$(\ls "${KOPSENV_CONF_DIR}/versions" \
     | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
     | grep -e "${regex}" \
     | head -n 1
@@ -27,7 +27,7 @@ fi
 
 version_exists() {
   local version="${1}"
-  [ -d "${KOPSENV_ROOT}/versions/${version}" ]
+  [ -d "${KOPSENV_CONF_DIR}/versions/${version}" ]
 }
 
 if version_exists "${KOPSENV_VERSION}"; then


### PR DESCRIPTION
This PR resolves the following:      
- New spot version releases no longer need to be hardcoded into the kopsenv codebase.   
- It's now possible to use either vanilla or spotinst versions of kops.    
- It's now possible to easily upgrade to different releases of spotinst which have the same version, but different SHA, which include some additional fixes
- kopsenv list-remote now prints error details when calls to github API fail, instead of simply succeeding with an empty output

Note: This version contains a breaking change. Instead of assuming that specific version numbers use spotinst, these now need to be explicitly referenced. Example: setting v1.18.2 would previously use spotinst version v1.18.2-6837c742a1, and now it would use the vanilla kops v1.18.2. In order to use spotinst version configurations that reference it should instead reference v1.18.2-6837c742a1-spotinst .         
